### PR TITLE
fix: align release-please outputs and lockfile updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,9 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
-      body: ${{ steps.release.outputs.body }}
+      release_created: ${{ steps.release.outputs['walicord--release_created'] }}
+      tag_name: ${{ steps.release.outputs['walicord--tag_name'] }}
+      body: ${{ steps.release.outputs['walicord--body'] }}
     steps:
       - id: release
         uses: googleapis/release-please-action@v4
@@ -52,9 +52,6 @@ jobs:
         with:
           toolchain: stable
           target: ${{ matrix.target }}
-
-      - name: Update Cargo.lock
-        run: cargo update
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -1,4 +1,7 @@
 {
+  "plugins": [
+    "cargo-workspace"
+  ],
   "packages": {
     "walicord": {
       "release-type": "rust",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2619,7 +2619,7 @@ dependencies = [
 
 [[package]]
 name = "walicord"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "dashmap 6.1.0",
  "dotenvy",


### PR DESCRIPTION
## Summary
- use manifest-scoped release-please outputs so build runs after releases
- enable cargo-workspace to update Cargo.lock in release PRs
- remove the no-op Cargo.lock update step in the release workflow