### PR TITLE
chore: use Wild on ubuntu builds and fix Windows packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
         with:
           components: clippy
 
+      - name: Use Wild linker
+        uses: davidlattimore/wild-action@latest
+
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,10 @@ jobs:
           toolchain: stable
           target: ${{ matrix.target }}
 
+      - name: Use Wild linker
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        uses: davidlattimore/wild-action@latest
+
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
         with:
@@ -62,7 +66,16 @@ jobs:
       - name: Build release
         run: cargo build --release --target ${{ matrix.target }}
 
-      - name: Create archive
+      - name: Create archive (Windows)
+        if: ${{ matrix.os == 'windows-latest' }}
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force release | Out-Null
+          Copy-Item "target/${{ matrix.target }}/release/walicord.exe" release/
+          Compress-Archive -Path release/* -DestinationPath "release-walicord-${{ matrix.target }}.zip"
+
+      - name: Create archive (Unix)
+        if: ${{ matrix.os != 'windows-latest' }}
         shell: bash
         run: |
           mkdir -p release


### PR DESCRIPTION
## Summary
- enable Wild linker for ubuntu CI and release builds
- fix Windows release archives by using Compress-Archive