### PR TITLE
chore: cache build artifacts in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
+        with:
+          cache-targets: true
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2


### PR DESCRIPTION
## Summary
- enable rust-cache target caching in CI to speed up repeat runs