### PR TITLE
chore: remove wild-action from CI workflows to restore caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,6 @@ jobs:
         with:
           components: clippy
 
-      - name: Use Wild linker
-        uses: davidlattimore/wild-action@latest
-
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,10 +53,6 @@ jobs:
           toolchain: stable
           target: ${{ matrix.target }}
 
-      - name: Use Wild linker
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        uses: davidlattimore/wild-action@latest
-
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
## Summary
- Remove wild-action from CI and release workflows to restore cargo caching
- The wild linker was preventing Swatinem/rust-cache from working properly