### PR TITLE
fix: propagate solver selection through workspace dependencies

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -33,6 +33,14 @@ Rustの開発環境がある場合の手順です。
    cargo run --release
    ```
 
+   **線形計画ソルバーの選択**
+
+   デフォルトではHiGHSソルバーを使用します。COIN-OR CBCソルバーを使用する場合は、デフォルトfeatureを無効化して`coin_cbc`を有効化します：
+
+   ```sh
+   cargo run --release --no-default-features --features coin_cbc,ja
+   ```
+
 ## Discordボットの作成
 
 1. [Discord Developer Portal](https://discord.com/developers/applications)にアクセスし、**New Application**をクリックして新しいアプリケーションを作成します。

--- a/walicord-infrastructure/Cargo.toml
+++ b/walicord-infrastructure/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 walicord-application = { path = "../walicord-application" }
 walicord-domain = { path = "../walicord-domain" }
 walicord-parser = { path = "../walicord-parser" }
-walicord-transfer-construction = { path = "../walicord-transfer-construction" }
+walicord-transfer-construction = { path = "../walicord-transfer-construction", default-features = false }
 
 [dev-dependencies]
 proptest = "1.9.0"

--- a/walicord/Cargo.toml
+++ b/walicord/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 [dependencies]
 walicord-application = { path = "../walicord-application" }
 walicord-domain = { path = "../walicord-domain" }
-walicord-infrastructure = { path = "../walicord-infrastructure" }
+walicord-infrastructure = { path = "../walicord-infrastructure", default-features = false }
 walicord-i18n = { path = "../walicord-i18n" }
 walicord-parser = { path = "../walicord-parser" }
 walicord-presentation = { path = "../walicord-presentation" }


### PR DESCRIPTION
Closes #41

## 修正内容

COIN-OR CBCソルバーを指定しても、内部依存クレートがデフォルトでHiGHSをビルドしようとする問題を修正しました。

### 変更点

- `walicord-infrastructure/Cargo.toml`: `walicord-transfer-construction` の `default-features = false` を追加
- `walicord/Cargo.toml`: `walicord-infrastructure` の `default-features = false` を追加
- `docs/setup.md`: 線形計画ソルバーの選択方法をドキュメント化

### ビルド方法

```bash
# HiGHS（デフォルト）
cargo run --release

# COIN-OR CBC
cargo run --release --no-default-features --features coin_cbc,ja
```