### PR TITLE
fix: remove highs from default features to allow solver selection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           tool: nextest
 
       - name: Run clippy
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --features highs,ja -- -D warnings
 
       - name: Run tests
-        run: cargo nextest run
+        run: cargo nextest run --features highs,ja

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
           cache-dev: false
 
       - name: Build release
-        run: cargo build --release --target ${{ matrix.target }}
+        run: cargo build --release --target ${{ matrix.target }} --features highs,ja
 
       - name: Create archive (Windows)
         if: ${{ matrix.os == 'windows-latest' }}

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -29,16 +29,17 @@ Rustの開発環境がある場合の手順です。
    ```
 3. **設定**: `.env`ファイルを作成し、必要な設定を行います。
 4. **実行**:
-   ```sh
-   cargo run --release
-   ```
 
    **線形計画ソルバーの選択**
 
-   デフォルトではHiGHSソルバーを使用します。COIN-OR CBCソルバーを使用する場合は、デフォルトfeatureを無効化して`coin_cbc`を有効化します：
+   ソルバーと言語をfeatureフラグで指定します：
 
    ```sh
-   cargo run --release --no-default-features --features coin_cbc,ja
+   # HiGHSソルバー（推奨）
+   cargo run --release --features highs,ja
+
+   # COIN-OR CBCソルバー
+   cargo run --release --features coin_cbc,ja
    ```
 
 ## Discordボットの作成

--- a/walicord-infrastructure/Cargo.toml
+++ b/walicord-infrastructure/Cargo.toml
@@ -14,7 +14,7 @@ proptest = "1.9.0"
 rstest = "0.26.1"
 
 [features]
-default = ["highs", "ja"]
+default = ["ja"]
 highs = ["walicord-transfer-construction/highs"]
 coin_cbc = ["walicord-transfer-construction/coin_cbc"]
 ja = ["walicord-parser/ja"]

--- a/walicord-transfer-construction/Cargo.toml
+++ b/walicord-transfer-construction/Cargo.toml
@@ -12,6 +12,5 @@ proptest = "1.9.0"
 rstest = "0.26.1"
 
 [features]
-default = ["highs"]
 coin_cbc = ["good_lp/coin_cbc"]
 highs = ["good_lp/highs"]

--- a/walicord/Cargo.toml
+++ b/walicord/Cargo.toml
@@ -28,7 +28,7 @@ rstest = "0.26.1"
 serde_json = "1.0"
 
 [features]
-default = ["highs", "ja"]
+default = ["ja"]
 highs = ["walicord-infrastructure/highs"]
 coin_cbc = ["walicord-infrastructure/coin_cbc"]
 ja = ["walicord-infrastructure/ja", "walicord-i18n/ja", "walicord-parser/ja"]


### PR DESCRIPTION
Closes #41

## 問題

`--features coin_cbc`を指定しても、内部的な依存関係によりhighsが常にビルドされてしまう。

## 修正内容

highsをデフォルトfeatureから削除し、ビルド時に明示的な選択が必要にしました。

### 変更点
- `walicord-transfer-construction/Cargo.toml`: `default = ["highs"]`を削除
- `walicord-infrastructure/Cargo.toml`: `highs`をデフォルトfeatureから削除
- `walicord/Cargo.toml`: `highs`をデフォルトfeatureから削除
- `docs/setup.md`: ビルド方法を更新
- CI/Releaseワークフロー: `--features highs,ja`を追加

### ビルド方法
```bash
# HiGHSを使用（推奨）
cargo run --release --features highs,ja

# COIN-OR CBCを使用
cargo run --release --features coin_cbc,ja
```