### PR TITLE
chore: add VSCode settings for rust-analyzer features

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "rust-analyzer.cargo.features": ["highs", "ja"]
+}


### PR DESCRIPTION
Add .vscode/settings.json to configure rust-analyzer with highs and ja
features enabled by default. This prevents "No solver available" errors
in VSCode after highs was removed from default features in #46.