### PR TITLE
feat: clarify settleup output with explicit statuses

### DIFF
--- a/walicord-i18n/src/lib.rs
+++ b/walicord-i18n/src/lib.rs
@@ -9,9 +9,14 @@ pub mod strings {
     pub const TO: &str = "受取人";
     pub const AMOUNT: &str = "金額";
     pub const CATEGORY: &str = "カテゴリ";
+    pub const STATUS: &str = "状態";
     pub const SETTLEMENT_PAYMENT: &str = "確定者の支払い";
     pub const PAYMENT_TO_SETTLOR: &str = "確定者への支払い";
     pub const PENDING: &str = "保留";
+    pub const SETTLED_MEMBER: &str = "確定対象";
+    pub const UNSETTLED_MEMBER: &str = "未確定";
+    pub const SETTLED_TRANSFER: &str = "確定済み";
+    pub const PLANNED_TRANSFER: &str = "参考";
     pub const SETTLEMENT_CALCULATION_FAILED: &str = "清算の計算に失敗しました";
     pub const SETTLEMENT_QUANTIZATION_FAILED: &str = "清算の丸めに失敗しました";
     pub const SETTLEMENT_QUANTIZATION_INVALID_ADJUSTMENT: &str =
@@ -22,8 +27,6 @@ pub mod strings {
         "清算の丸めに失敗しました (ゼロサム整合性を満たせませんでした)";
     pub const SETTLEMENT_QUANTIZATION_NON_INTEGRAL: &str =
         "清算の丸めに失敗しました (整数化できません)";
-    pub const MISSING_MEMBERS_DECLARATION: &str =
-        "チャンネルのtopicに `MEMBERS := ...` の宣言が見つかりません。";
 }
 
 #[cfg(feature = "en")]
@@ -34,9 +37,14 @@ pub mod strings {
     pub const TO: &str = "To";
     pub const AMOUNT: &str = "Amount";
     pub const CATEGORY: &str = "Category";
+    pub const STATUS: &str = "Status";
     pub const SETTLEMENT_PAYMENT: &str = "Settlement Payment";
     pub const PAYMENT_TO_SETTLOR: &str = "Payment to Settlor";
     pub const PENDING: &str = "Pending";
+    pub const SETTLED_MEMBER: &str = "Settled";
+    pub const UNSETTLED_MEMBER: &str = "Not settled";
+    pub const SETTLED_TRANSFER: &str = "Confirmed";
+    pub const PLANNED_TRANSFER: &str = "Plan";
     pub const SETTLEMENT_CALCULATION_FAILED: &str = "Settlement calculation failed";
     pub const SETTLEMENT_QUANTIZATION_FAILED: &str = "Settlement quantization failed";
     pub const SETTLEMENT_QUANTIZATION_INVALID_ADJUSTMENT: &str =
@@ -47,8 +55,6 @@ pub mod strings {
         "Settlement quantization failed (zero-sum invariant violation)";
     pub const SETTLEMENT_QUANTIZATION_NON_INTEGRAL: &str =
         "Settlement quantization failed (non-integral amount)";
-    pub const MISSING_MEMBERS_DECLARATION: &str =
-        "Could not find `MEMBERS := ...` declaration in the channel topic.";
 }
 
 #[cfg(not(any(feature = "ja", feature = "en")))]
@@ -59,9 +65,14 @@ pub mod strings {
     pub const TO: &str = "To";
     pub const AMOUNT: &str = "Amount";
     pub const CATEGORY: &str = "Category";
+    pub const STATUS: &str = "Status";
     pub const SETTLEMENT_PAYMENT: &str = "Settlement Payment";
     pub const PAYMENT_TO_SETTLOR: &str = "Payment to Settlor";
     pub const PENDING: &str = "Pending";
+    pub const SETTLED_MEMBER: &str = "Settled";
+    pub const UNSETTLED_MEMBER: &str = "Not settled";
+    pub const SETTLED_TRANSFER: &str = "Confirmed";
+    pub const PLANNED_TRANSFER: &str = "Plan";
     pub const SETTLEMENT_CALCULATION_FAILED: &str = "Settlement calculation failed";
     pub const SETTLEMENT_QUANTIZATION_FAILED: &str = "Settlement quantization failed";
     pub const SETTLEMENT_QUANTIZATION_INVALID_ADJUSTMENT: &str =
@@ -72,8 +83,6 @@ pub mod strings {
         "Settlement quantization failed (zero-sum invariant violation)";
     pub const SETTLEMENT_QUANTIZATION_NON_INTEGRAL: &str =
         "Settlement quantization failed (non-integral amount)";
-    pub const MISSING_MEMBERS_DECLARATION: &str =
-        "Could not find `MEMBERS := ...` declaration in the channel topic.";
 }
 
 pub use strings::*;


### PR DESCRIPTION
## Summary
- switch settleup output to explicit status labels for confirmed vs planned transfers
- show settled vs unsettled members directly in the balance table
- drop unused i18n strings while adding new status labels

Resolves #51