### PR TITLE
fix: prevent identifier parser from consuming reserved keywords

### DIFF
--- a/walicord-parser/src/lib.rs
+++ b/walicord-parser/src/lib.rs
@@ -390,12 +390,26 @@ fn mention_sequence_weighted(input: &str) -> PResult<'_, SetExpr<'_>> {
     mention_sequence_generic(mention_or_role_weighted, input)
 }
 
+fn is_reserved_keyword(word: &str) -> bool {
+    paid_keyword(word).is_ok_and(|(rest, _)| rest.is_empty())
+        || to_keyword(word).is_ok_and(|(rest, _)| rest.is_empty())
+        || ga(word).is_ok_and(|(rest, _)| rest.is_empty())
+        || ni(word).is_ok_and(|(rest, _)| rest.is_empty())
+}
+
 fn identifier(input: &str) -> PResult<'_, &str> {
-    recognize((
+    let (rest, ident) = recognize((
         take_while1(|c: char| c.is_alphanumeric() || c == '_' || is_japanese_char(c)),
         take_while(|c: char| c.is_alphanumeric() || c == '_' || c == '-' || is_japanese_char(c)),
     ))
-    .parse(input)
+    .parse(input)?;
+    if is_reserved_keyword(ident) {
+        return Err(nom::Err::Error(NomSyntaxError::from_error_kind(
+            input,
+            ErrorKind::Tag,
+        )));
+    }
+    Ok((rest, ident))
 }
 
 fn is_japanese_char(c: char) -> bool {
@@ -1550,6 +1564,17 @@ mod tests {
             kind: SyntaxErrorKind::ParseFailure {
                 attempted_form: Some("<PAYER> が <PAYEE> に <AMOUNT> 立て替えた"),
                 expected: ExpectedElement::Amount,
+                near: "立て替えた".to_string(),
+            },
+        })
+    )]
+    #[case::ja_payment_missing_payee(
+        "<@123> が 立て替えた",
+        Err(ParseError::SyntaxError {
+            line: 1,
+            kind: SyntaxErrorKind::ParseFailure {
+                attempted_form: Some("<PAYER> が <PAYEE> に <AMOUNT> 立て替えた"),
+                expected: ExpectedElement::MemberOrGroup,
                 near: "立て替えた".to_string(),
             },
         })


### PR DESCRIPTION
## Summary
- `identifier` パーサーが日本語キーワード（`立て替えた` 等）をグループ名として貪欲に消費し、後続パーサーが空入力で失敗することで「文が途中で終わっています」という誤ったエラーメッセージが出ていた問題を修正
- 既存の keyword parser (`paid_keyword`, `to_keyword`, `ga`, `ni`) を single source of truth として `is_reserved_keyword()` を導入し、`identifier()` 内で予約語の完全一致を拒否するように変更
- `<@123> が 立て替えた` で `near: "立て替えた"`, `expected: MemberOrGroup` が正しく報告されるテストケースを追加

## Test plan
- [x] 既存 110 テスト全パス
- [x] 新規テストケース `ja_payment_missing_payee` パス
- [x] `to-team`, `tokyo` 等の to-prefix グループ名が引き続きパース可能
- [x] clippy / fmt クリーン